### PR TITLE
Add release (ie. 0.5.5/e9d4379) to sentry logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- [Sentry] - Log version as sentry 'release'
 - [CLI] - Name the process - bcnode
 - [Global] - Added benchmark module
 - [Engine] - Add stats/monitor

--- a/src/cli/main.es6
+++ b/src/cli/main.es6
@@ -36,10 +36,11 @@ export const main = async (args: string[] = process.argv) => {
   process.title = 'bcnode'
 
   const version = getVersion()
+  const versionString = `${version.npm}#${version.git.short}`
 
   program
     // $FlowFixMe
-    .version(`${version.npm}#${version.git.short}`)
+    .version(versionString)
     .usage('<cmd>')
     .action((cmd) => {
       console.log(colors.red(`Invalid command '${cmd}'`))
@@ -100,7 +101,7 @@ export const main = async (args: string[] = process.argv) => {
   native.initLogger()
 
   // Initialize error handlers
-  initErrorHandlers(logger)
+  initErrorHandlers(logger, versionString)
 
   // Parse command line
   return program.parse(args)
@@ -116,9 +117,11 @@ const initDirs = () => {
   }
 }
 
-const initErrorHandlers = (logger: Logger) => {
+const initErrorHandlers = (logger: Logger, versionString: string) => {
   if (config.sentry.enabled) {
-    Raven.config(config.sentry.url).install()
+    Raven.config(config.sentry.url, {
+      release: versionString
+    }).install()
   }
 
   // setup logging of unhandled rejections


### PR DESCRIPTION
### General

- [N/A] If adding new feature, did you add test for it?
- [ ] Did you change protobuf definitions?
	- [ ] Does the code work with both old and new structure?
- [N/A] Did you add appropriate logs for new code? In proper levels?
- [x] Did you remove all `console.log`s / `println!()`s used for debugging (or replaced with `log.debug()` / `trace!()` respectively)?

### Docs

- [N/A] Are your public js methods / functions properly documented (using ESDoc tags)?
- [N/A] Is your rust code properly documented?
- [x] Did you add you change to CHANGELOG.md?

### Other

- [x] Did you run `yarn run dist` locally without errors?
- [x] Did you try to run the node with all subsystems (UI+WS, P2P node, rovers, persistence)?
- [x] Did you try to rebase on top of base branch?
- [x] Have you squashed all "fix typo"-kind and `fixup!` commits?

### If fixing bug

- [N/A] Did you add test so that we don't introduce it again?
- [N/A] If fixing existing GitHub issue does this PR contain `Closes #<PR>` reference?
