### PR TITLE
[WIP] Another cleanup of BTC rover

### DIFF
--- a/src/rover/btc/index.es6
+++ b/src/rover/btc/index.es6
@@ -8,4 +8,4 @@
  */
 
 export { default as Controller } from './controller'
-export { default as Network } from './network'
+export { Network } from './network'


### PR DESCRIPTION
- do not track discovered / satoshi peers separately - getter now counts
from network.peers structure
- remove unused fields from network.state structure, add flow type
- rename network.setState -> network.updateBestHeight to better reflect what
the method actually does
- network.bestHeight now is guaranteed to be monotonically increasing
- let network.pool handle disconnects internally, just remove the
disconnected peer from network._state.peers

### General

- [x] Did you add appropriate logs for new code? In proper levels?
- [x] Did you remove all `console.log`s / `println!()`s used for debugging (or replaced with `log.debug()` / `trace!()` respectively)?

### Other

- [x] Did you run `yarn run dist` locally without errors?
- [x] Did you try to run the node with all subsystems (UI+WS, P2P node, rovers, persistence)?
- [x] Did you try to rebase on top of base branch?
- [x] Have you squashed all "fix typo"-kind and `fixup!` commits?